### PR TITLE
Added Dosis font to todo buttons

### DIFF
--- a/src/css/todos/sidebar.css
+++ b/src/css/todos/sidebar.css
@@ -84,6 +84,7 @@
   border: none;
   background: var(--btnBg);
   color: var(--btnFg);
+  font-family: "Dosis", sans-serif;
   justify-content: center;
   border-radius: 0.5rem;
   margin-top: 1rem;


### PR DESCRIPTION
The Dosis font was not rendering for me for the todo buttons: adding a project, adding a todo and clearing the todos. It was Arial instead. This change fixed that for me.