### PR TITLE
Improve readability and fix rendering

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,7 +11,7 @@ import TodoPage from "./components/todoPage.jsx";
 import { switchTheme } from "./utils";
 
 import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOMClient from 'react-dom/client';
 
 import { Route } from "wouter";
 
@@ -40,5 +40,5 @@ function App() {
   ? switchTheme("light")
   : switchTheme(localStorage.theme);
 
-const root = ReactDOM.createRoot(document.getElementById("app"));
+const root = ReactDOMClient.createRoot(document.getElementById("app"));
 root.render(<App />);

--- a/src/utils.jsx
+++ b/src/utils.jsx
@@ -1,15 +1,9 @@
 import { volume } from "./store";
 
 function numToText(min, sec) {
-  let temp;
-
-  if (min < 10) temp = `0${min} : ${sec}`;
-  else if (sec < 10) temp = `${min} : 0${sec}`;
-  else {
-    temp = `${min} : ${sec}`;
-  }
-
-  return temp;
+  if (min < 10) min = `0${min}`;
+  if (sec < 10) sec = `0${sec}`;
+  return `${min} : ${sec}`;
 }
 
 function setProgressValue(ogTime, newTime) {
@@ -18,16 +12,15 @@ function setProgressValue(ogTime, newTime) {
   return timeProgres;
 }
 
-const playSound = (path) => {
+function playSound(path) {
   let n = document.querySelector("audio");
   n.setAttribute("src", path);
   n.volume = volume.value / 100;
   n.play();
 };
 
-export function switchTheme(name) {
-  let body = document.querySelector("body");
-  body.setAttribute("data-theme", name);
+function switchTheme(name) {
+  document.body.dataset.theme = name;
   localStorage.setItem("theme", name);
 }
 
@@ -38,4 +31,4 @@ let progressBar = {
   pathTransitionDuration: 0.3,
 };
 
-export { numToText, playSound, progressBar, setProgressValue };
+export { numToText, playSound, progressBar, switchTheme, setProgressValue };


### PR DESCRIPTION
Improve readability of `src/utils.jsx`: a bit more consistent code, and the `numToText` function can now prefix both minutes and seconds with a 0 at the same time. FYI you can just get the body with `document.body`, no need to use `document.querySelector`.

Fix rendering: `createRoot` is a method of `ReactDOMClient`, not `ReactDOM`, this might be an issue from me, so sorry if that's the case.